### PR TITLE
Condiciones comerciales editables en lista

### DIFF
--- a/src/app/cotizador/page.tsx
+++ b/src/app/cotizador/page.tsx
@@ -14,6 +14,12 @@ import {
   getTodayDateString,
   getDefaultValidUntil,
 } from '@/lib/quote-dates';
+import {
+  DEFAULT_COMMERCIAL_TERMS,
+  commercialTermsFromString,
+  commercialTermsToString,
+} from '@/lib/commercial-terms';
+import { CommercialTermsEditor } from '@/components/CommercialTermsEditor';
 
 type QuoteItem = {
   id: string;
@@ -117,7 +123,9 @@ function CotizadorContent() {
     show_valid_until: true
   });
 
-  const [useCustomTerms, setUseCustomTerms] = useState(false);
+  const [commercialTerms, setCommercialTerms] = useState<string[]>([
+    ...DEFAULT_COMMERCIAL_TERMS,
+  ]);
 
   const [items, setItems] = useState<QuoteItem[]>([
     {
@@ -197,6 +205,10 @@ function CotizadorContent() {
           custom_commercial_terms: quote.custom_commercial_terms || '',
           show_valid_until: quote.show_valid_until ?? true,
         }));
+
+        setCommercialTerms(
+          commercialTermsFromString(quote.custom_commercial_terms)
+        );
 
         const templateItems = (quote.quote_items || []).map((item, index) => {
           const quantity = Number(item.quantity) || 1;
@@ -347,6 +359,7 @@ function CotizadorContent() {
         },
         body: JSON.stringify({
           ...formData,
+          custom_commercial_terms: commercialTermsToString(commercialTerms) || null,
           items,
           subtotal,
           tax,
@@ -1040,41 +1053,13 @@ function CotizadorContent() {
 
                 {/* Commercial Terms */}
                 <div className="mt-4 p-4 bg-surface-secondary rounded-xl">
-                  <div className="flex items-center justify-between mb-3">
-                    <label className="flex items-center gap-2 cursor-pointer">
-                      <input
-                        type="checkbox"
-                        checked={useCustomTerms}
-                        onChange={(e) => {
-                          setUseCustomTerms(e.target.checked);
-                          if (!e.target.checked) {
-                            setFormData({ ...formData, custom_commercial_terms: '' });
-                          }
-                        }}
-                        className="w-4 h-4 text-accent border-gray-300 rounded focus:ring-accent"
-                      />
-                      <span className="text-sm font-medium text-gray-700">Usar condiciones comerciales personalizadas</span>
-                    </label>
-                  </div>
-                  {useCustomTerms ? (
-                    <textarea
-                      name="custom_commercial_terms"
-                      value={formData.custom_commercial_terms}
-                      onChange={handleFormChange}
-                      rows={4}
-                      className="input resize-none font-mono text-sm"
-                      placeholder="• Condición 1&#10;• Condición 2&#10;• Condición 3"
-                    />
-                  ) : (
-                    <div className="text-sm text-muted space-y-1">
-                      <p className="font-medium text-gray-600">Condiciones por defecto:</p>
-                      <ul className="list-disc list-inside space-y-0.5 text-muted-light">
-                        <li>Validez de 30 días</li>
-                        <li>Pesos mexicanos (MXN), sin IVA</li>
-                        <li>50% anticipo, 50% al finalizar</li>
-                      </ul>
-                    </div>
-                  )}
+                  <label className="block text-sm font-medium text-gray-700 mb-3">
+                    Condiciones comerciales
+                  </label>
+                  <CommercialTermsEditor
+                    terms={commercialTerms}
+                    onChange={setCommercialTerms}
+                  />
                 </div>
 
                 {/* Navigation */}

--- a/src/app/dashboard/cotizaciones/editar/[id]/editar-cotizacion-client.tsx
+++ b/src/app/dashboard/cotizaciones/editar/[id]/editar-cotizacion-client.tsx
@@ -11,6 +11,11 @@ import { SessionUser } from '@/types/session';
 import { generateQuotePDF } from '@/lib/pdf-generator';
 import { QUOTE_ITEM_UNIT_OPTIONS, normalizeQuoteItemUnit } from '@/lib/quote-item-units';
 import { isoToDateInput, dateInputToISO } from '@/lib/quote-dates';
+import {
+  commercialTermsFromString,
+  commercialTermsToString,
+} from '@/lib/commercial-terms';
+import { CommercialTermsEditor } from '@/components/CommercialTermsEditor';
 
 const serviceTypes = [
   { value: 'cctv', label: 'CCTV y Videovigilancia', icon: '📹' },
@@ -62,7 +67,9 @@ export default function EditarCotizacionClient({
     status: normalizeQuoteStatus(quote.status)
   });
 
-  const [useCustomTerms, setUseCustomTerms] = useState(!!quote.custom_commercial_terms);
+  const [commercialTerms, setCommercialTerms] = useState<string[]>(
+    commercialTermsFromString(quote.custom_commercial_terms)
+  );
 
   const [items, setItems] = useState<QuoteItem[]>(
     quote.quote_items.map(item => ({
@@ -92,7 +99,7 @@ export default function EditarCotizacionClient({
 
   useEffect(() => {
     setHasChanges(true);
-  }, [formData, items, clientFields]);
+  }, [formData, items, clientFields, commercialTerms]);
 
   const searchClientsForEdit = async (query: string) => {
     if (query.length < 2) {
@@ -213,6 +220,7 @@ export default function EditarCotizacionClient({
           client_phone: clientFields.client_phone.trim() || null,
           client_company: clientFields.client_company.trim() || null,
           ...formData,
+          custom_commercial_terms: commercialTermsToString(commercialTerms) || null,
           status: normalizeQuoteStatus(formData.status),
           items: items.map(item => ({
             id: item.id,
@@ -256,7 +264,7 @@ export default function EditarCotizacionClient({
         service_type: formData.service_type,
         description: formData.description || '',
         valid_until: formData.valid_until,
-        custom_commercial_terms: formData.custom_commercial_terms,
+        custom_commercial_terms: commercialTermsToString(commercialTerms) || null,
         show_valid_until: formData.show_valid_until,
         items: items.map(item => ({
           item_name: item.description || '',
@@ -713,43 +721,11 @@ export default function EditarCotizacionClient({
 
             {/* Commercial Terms */}
             <div className="bg-white rounded-2xl shadow-card p-6">
-              <div className="flex items-center justify-between mb-4">
-                <h2 className="text-lg font-semibold text-gray-900">Condiciones Comerciales</h2>
-                <label className="flex items-center gap-2 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={useCustomTerms}
-                    onChange={(e) => {
-                      setUseCustomTerms(e.target.checked);
-                      if (!e.target.checked) {
-                        setFormData({ ...formData, custom_commercial_terms: '' });
-                      }
-                    }}
-                    className="w-4 h-4 text-accent border-gray-300 rounded focus:ring-accent"
-                  />
-                  <span className="text-sm font-medium text-gray-700">Personalizadas</span>
-                </label>
-              </div>
-
-              {useCustomTerms ? (
-                <textarea
-                  name="custom_commercial_terms"
-                  value={formData.custom_commercial_terms || ''}
-                  onChange={handleFormChange}
-                  rows={4}
-                  className="input resize-none font-mono text-sm"
-                  placeholder="• Condición 1&#10;• Condición 2&#10;• Condición 3"
-                />
-              ) : (
-                <div className="p-4 bg-surface-secondary rounded-xl text-sm text-muted space-y-1">
-                  <p className="font-medium text-gray-600 mb-2">Condiciones por defecto:</p>
-                  <ul className="list-disc list-inside space-y-0.5">
-                    <li>Validez de 30 días</li>
-                    <li>Pesos mexicanos (MXN), sin IVA</li>
-                    <li>50% anticipo, 50% al finalizar</li>
-                  </ul>
-                </div>
-              )}
+              <h2 className="text-lg font-semibold text-gray-900 mb-4">Condiciones Comerciales</h2>
+              <CommercialTermsEditor
+                terms={commercialTerms}
+                onChange={setCommercialTerms}
+              />
             </div>
 
             {/* Actions */}

--- a/src/components/CommercialTermsEditor.tsx
+++ b/src/components/CommercialTermsEditor.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+type CommercialTermsEditorProps = {
+  terms: string[];
+  onChange: (terms: string[]) => void;
+};
+
+export function CommercialTermsEditor({ terms, onChange }: CommercialTermsEditorProps) {
+  const updateTerm = (index: number, value: string) => {
+    onChange(terms.map((term, i) => (i === index ? value : term)));
+  };
+
+  const addTerm = () => {
+    onChange([...terms, '']);
+  };
+
+  const removeTerm = (index: number) => {
+    if (terms.length <= 1) {
+      onChange(['']);
+      return;
+    }
+    onChange(terms.filter((_, i) => i !== index));
+  };
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-muted">
+        Condiciones que aparecerán en el PDF. Puedes editarlas, agregar o quitar líneas.
+      </p>
+      <ul className="space-y-2">
+        {terms.map((term, index) => (
+          <li key={index} className="flex items-start gap-2">
+            <span className="mt-2.5 text-muted select-none" aria-hidden>
+              •
+            </span>
+            <input
+              type="text"
+              value={term}
+              onChange={(e) => updateTerm(index, e.target.value)}
+              className="input flex-1"
+              placeholder={`Condición ${index + 1}`}
+            />
+            <button
+              type="button"
+              onClick={() => removeTerm(index)}
+              className="mt-1 p-2 rounded-lg text-muted hover:text-danger hover:bg-danger/5 transition-colors"
+              title="Quitar condición"
+              aria-label={`Quitar condición ${index + 1}`}
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </li>
+        ))}
+      </ul>
+      <button
+        type="button"
+        onClick={addTerm}
+        className="inline-flex items-center gap-2 text-sm font-medium text-accent hover:text-accent-dark transition-colors"
+      >
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+        </svg>
+        Agregar condición
+      </button>
+    </div>
+  );
+}

--- a/src/lib/commercial-terms.ts
+++ b/src/lib/commercial-terms.ts
@@ -1,0 +1,37 @@
+/** Condiciones comerciales por defecto (editables en cotizador/edición). */
+export const DEFAULT_COMMERCIAL_TERMS = [
+  'Validez de 30 días',
+  'Pesos mexicanos (MXN), sin IVA',
+  '50% anticipo, 50% al finalizar',
+] as const;
+
+/** Convierte líneas del formulario a texto para BD/PDF (con viñeta). */
+export function commercialTermsToString(terms: string[]): string {
+  return terms
+    .map((t) => t.trim())
+    .filter(Boolean)
+    .map((t) => (t.startsWith('•') ? t : `• ${t}`))
+    .join('\n');
+}
+
+/** Parsea texto guardado a lista editable (sin viñetas). Si vacío, usa defaults. */
+export function commercialTermsFromString(
+  value: string | null | undefined,
+  options?: { fallbackToDefaults?: boolean }
+): string[] {
+  const fallbackToDefaults = options?.fallbackToDefaults !== false;
+  if (!value?.trim()) {
+    return fallbackToDefaults ? [...DEFAULT_COMMERCIAL_TERMS] : [''];
+  }
+
+  const parsed = value
+    .split('\n')
+    .map((line) => line.replace(/^[•\-\*]\s*/, '').trim())
+    .filter(Boolean);
+
+  if (parsed.length === 0) {
+    return fallbackToDefaults ? [...DEFAULT_COMMERCIAL_TERMS] : [''];
+  }
+
+  return parsed;
+}


### PR DESCRIPTION
Reemplaza el checkbox que borraba los términos por una lista editable con los valores por defecto precargados, en cotizador y edición.